### PR TITLE
bump version & add sort styles rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -135,6 +135,13 @@ module.exports = {
         },
       },
     ],
+
+    // Sort RN styles, this will sort typed stylenames and style props in alphabetic order
+    'react-native/sort-styles': [
+      'error',
+      'asc',
+      { ignoreClassNames: false, ignoreStyleProperties: false },
+    ],
   },
   settings: {
     'import/resolver': {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added 
+
+- Added react-native/sort-styles rule by [@ThomasGoatITMedia](https://github.com/ThomasGoatITMedia) PR #1
+
+## [1.0.0] - 2021-03-22
+
+- Initial commit by [@isilher](https://github.com/isilher).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native.git"
   },
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "eslint config for react native projects developed by the MIG",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native.git"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "eslint config for react native projects developed by the MIG",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/33637221/114380024-db7a9200-9b89-11eb-96ef-07c55e407b16.gif)

## Proposal:
I find it very useful to sort the stylesheet names/properties alphabetically.

## Why should we make the proposed changes?
Because styles are always the same set of names/properties we can sort this for easier reading and consistency

## What will the impact of the changes be?
In the Reisbalans app we used to have this so impact shouldn't be big, in new projects this could add a lot of changes/warnings.
