### PR TITLE
publish to npmjs workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,47 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,7 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - run: npm ci
       - run: npm test
 
-  publish-npm:
+  publish-npm: # publish to npmjs
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -30,9 +30,9 @@ jobs:
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-  publish-gpr:
+  publish-gpr: # publish to github package repo
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,18 +8,7 @@ on:
     types: [published]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 12
-      - run: npm ci
-      - run: npm test
-
   publish-npm: # publish to npmjs
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,6 +16,8 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm test
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,21 +27,6 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
-  publish-gpr: # publish to github package repo
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 12
-          registry-url: https://npm.pkg.github.com/
-      - run: npm ci
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added 
+## [1.1.1] - 2021-04-14
 
-- Added react-native/sort-styles rule by [@ThomasGoatITMedia](https://github.com/ThomasGoatITMedia) PR #1
+### Added
+
+- Added auto release workflow to releaswe npmjs & bump version [@ThomasGoatITMedia](https://github.com/ThomasGoatITMedia) PR [#3](https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native/pull/3)
+
+## [1.1.0] - 2021-04-13
+
+### Added
+
+- Added react-native/sort-styles rule by [@ThomasGoatITMedia](https://github.com/ThomasGoatITMedia) PR [#1](https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native/pull/1)
 
 ## [1.0.0] - 2021-03-22
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,13 @@ Account needs 2FA enabled for authorization & publishing.
 
 ### Step 1 - Bump version
 
-Create a new branch in which you bump the version, in here you'll also need to update [CHANGELOG.md](https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native/blob/main/CHANGELOG.md). Move everything from [Unreleased] to the new version that you're creating. Using `npm version` you can bump the version.
+Create a new branch in which you bump the version and use the following naming convention:
+
+```
+version/1.2.3
+```
+
+In your new branch you'll also need to update [CHANGELOG.md](https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native/blob/main/CHANGELOG.md). Move everything from [Unreleased] to the new version that you're creating. Using `npm version` you can bump the version.
 
 ```
 npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,31 @@ rules: {
 6. Use the warnings to ensure the correct code style is used with any new features and changes.
 7. One by one, remove the custom rules and refactor the codebase as required. You could create stories for each of them and plan in one or two every sprint or whenever your team has time to work on clearing technical debt.
 
+## Publishing to npmjs.com
+
+### prerequisites
+
+You’ll need an account on npmjs.com and that has access to this package.
+Account needs 2FA enabled for authorization & publishing.
+
+### Step 1 - Bump version
+
+Create a new branch in which you bump the version, in here you'll also need to update [CHANGELOG.md](https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native/blob/main/CHANGELOG.md). Move everything from [Unreleased] to the new version that you're creating. Using `npm version` you can bump the version.
+
+```
+npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]
+```
+
+Push your new branch and create a PR, **wait for it being approved and merged before proceeding with the next steps.**
+
+### Step 2 - Create draft release
+
+Go to [releases](https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native/releases) and create a new draft release. Make sure the version number is the same as in step 1! In here you can also edit the release note and publish it.
+
+### Step 4 - publish!
+
+Once you've published the draft release a github workflow should kick off that will publish it on our [npmjs package](https://www.npmjs.com/package/eslint-config-mig-react-native)
+
 ## Contribution
 
 As stated in the Goals, this repository can be used as a platform to discuss and update our codestyling configuration. If you have a proposal:

--- a/README.md
+++ b/README.md
@@ -91,13 +91,15 @@ rules: {
 You’ll need an account on npmjs.com and that has access to this package.
 Account needs 2FA enabled for authorization & publishing.
 
-### Step 1 - Bump version
+### Step 1 - Create a new branch
 
 Create a new branch in which you bump the version and use the following naming convention:
 
 ```
 version/1.2.3
 ```
+
+### Step 2 - Bump version
 
 In your new branch you'll also need to update [CHANGELOG.md](https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native/blob/main/CHANGELOG.md). Move everything from [Unreleased] to the new version that you're creating. Using `npm version` you can bump the version.
 
@@ -107,7 +109,7 @@ npm version [<newversion> | major | minor | patch | premajor | preminor | prepat
 
 Push your new branch and create a PR, **wait for it being approved and merged before proceeding with the next steps.**
 
-### Step 2 - Create draft release
+### Step 3 - Create draft release
 
 Go to [releases](https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native/releases) and create a new draft release. Make sure the version number is the same as in step 1! In here you can also edit the release note and publish it.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native.git"
   },
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "eslint config for react native projects developed by the MIG",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
![](https://media.giphy.com/media/NmerZ36iBkmKk/source.gif) 

In this PR I've updated the readme with documentation about how to release a new version and I've created a GitHub workflow that should automagically release on npmjs as well.

In previous release the version number wasn't pushed due to the protected main/master branch. This PR fixes the version bump and when following the steps should fix that in the future.