### PR TITLE
add new rule: sort jsx props, warn if the rule is violated

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -145,7 +145,7 @@ module.exports = {
 
     // Sort props for JSX component
     'react/jsx-sort-props': [
-      'warn',
+      'error',
       {
         callbacksLast: true,
         ignoreCase: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,6 +142,15 @@ module.exports = {
       'asc',
       { ignoreClassNames: false, ignoreStyleProperties: false },
     ],
+
+    // Sort props for JSX component
+    'react/jsx-sort-props': [
+      'warn',
+      {
+        callbacksLast: true,
+        ignoreCase: true,
+      },
+    ],
   },
   settings: {
     'import/resolver': {


### PR DESCRIPTION

![image](https://cdn.dribbble.com/users/1308090/screenshots/3350349/stockin.gif)


## Proposal: 
sort props for JSX components

## Why should we make the proposed changes?

* Easier to read and look for certain props with the unfamiliar codebase, especially then component receives a lot of props
* Allways aware that props comes first and callbacks at the end of the list

## What will the impact of the changes be?

* rearranging the props in JSX components. If the rule is violated, then the developer will be warned about that
