### PR TITLE
add missing dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn add -D eslint-config-mig-react-native
 Install the package peer dependencies as development depency (if you don't have them allready).
 
 ```bash
-yarn add -D eslint eslint-config-prettier eslint-plugin-detox eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-react eslint-plugin-react-hooks prettier
+yarn add -D eslint eslint-config-prettier eslint-plugin-detox eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-react eslint-plugin-react-hooks prettier prettier-eslint-cli @react-native-community/eslint-config typescript @typescript-eslint/parser @typescript-eslint/eslint-plugin
 ```
 
 ## ESLint configuration


### PR DESCRIPTION
![readme](https://media.giphy.com/media/WoWm8YzFQJg5i/giphy.gif)

## Proposal:

Update the README to add missing dependencies to the installation instructions.

## Why should we make the proposed changes?

When adding the config to an empty project, these dependencies are required to work with eslint, prettier and typescript.

## What will the impact of the changes be?

Users installing the config will now get the correct dependency installation command when copying from our README. 

We will not need to make a new release: this PR updates the README only, which will be reflected immediately after merging.