### PR TITLE
Added sort imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -136,6 +136,17 @@ module.exports = {
       },
     ],
 
+    // Sort imports in a default alphabetic order
+    'sort-imports': [
+      'error', {
+        'ignoreCase': false,
+        'ignoreDeclarationSort': false,
+        'ignoreMemberSort': false,
+        'memberSyntaxSortOrder': ["none", "all", "multiple", "single"],
+        'allowSeparatedGroups': false
+      }
+    ],
+
     // Sort RN styles, this will sort typed stylenames and style props in alphabetic order
     'react-native/sort-styles': [
       'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.5] - 2022-01-19
+- Added sorted imports: Sort imports using the recommended sort rule (https://eslint.org/docs/rules/sort-imports)
+
 ## [1.1.4] - 2021-05-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mig-react-native",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native.git"
   },
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "eslint config for react native projects developed by the MIG",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
![import order](https://media.tenor.co/images/6a42fdf8e384965af6b76a1ba80b58e2/tenor.gif)

## Proposal:
Add import rules to allow automatic sorting and importing on save. Also give a consistent sorting behaviour across IDE's, developers and projects. This is a start using the recommended template of eslint: https://eslint.org/docs/rules/sort-imports


## Why should we make the proposed changes?
To allow easier code with automatic formatting the imports.

## What will the impact of the changes be?
Changes in many files as the imports are currently not ordered. In the long run it will safe time and consistency across projects.
