### PR TITLE
Replace import sort

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   extends: ['@react-native-community', 'airbnb', 'airbnb/hooks', 'prettier'],
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'detox'],
+  plugins: ['@typescript-eslint', 'detox', 'simple-import-sort'],
   ignorePatterns: ['*.graphql', 'graphql.ts', 'src/locales/'],
   globals: { React: true, JSX: true },
   env: { jest: true },
@@ -13,10 +13,7 @@ module.exports = {
     'import/no-extraneous-dependencies': [
       2,
       {
-        devDependencies: [
-          '**/*.{stories,story}.[jt]s?(x)',
-          '**/*.spec.[jt]s?(x)',
-        ],
+        devDependencies: ['**/*.{stories,story}.[jt]s?(x)', '**/*.spec.[jt]s?(x)'],
       },
     ],
 
@@ -97,13 +94,7 @@ module.exports = {
     'react/sort-comp': [
       2,
       {
-        order: [
-          'static-variables',
-          'static-methods',
-          'lifecycle',
-          'everything-else',
-          'render',
-        ],
+        order: ['static-variables', 'static-methods', 'lifecycle', 'everything-else', 'render'],
         groups: {
           lifecycle: [
             'displayName',
@@ -137,22 +128,11 @@ module.exports = {
     ],
 
     // Sort imports in a default alphabetic order
-    'sort-imports': [
-      'error', {
-        'ignoreCase': false,
-        'ignoreDeclarationSort': false,
-        'ignoreMemberSort': false,
-        'memberSyntaxSortOrder': ["none", "all", "multiple", "single"],
-        'allowSeparatedGroups': false
-      }
-    ],
+    'simple-import-sort/imports': 'error',
+    'simple-import-sort/exports': 'error',
 
     // Sort RN styles, this will sort typed stylenames and style props in alphabetic order
-    'react-native/sort-styles': [
-      'error',
-      'asc',
-      { ignoreClassNames: false, ignoreStyleProperties: false },
-    ],
+    'react-native/sort-styles': ['error', 'asc', { ignoreClassNames: false, ignoreStyleProperties: false }],
 
     // Sort props for JSX component
     'react/jsx-sort-props': [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.6] - 2022-01-19
+
+- Replace sort-imports with simple import sorting plugin to prevent rule conflict and allow autofix (https://github.com/lydell/eslint-plugin-simple-import-sort)
+
 ## [1.1.5] - 2022-01-19
+
 - Added sorted imports: Sort imports using the recommended sort rule (https://eslint.org/docs/rules/sort-imports)
 
 ## [1.1.4] - 2021-05-27
@@ -16,13 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added JSX sorted props: first props and then callbacks all in ascending order
 
-
 ## [1.1.3] - 2021-05-10
 
 ### Removed
 
 - Remove `npm run test` from `npm-publish` workflow & bump version [@ThomasGoatITMedia](https://github.com/ThomasGoatITMedia) PR [#5](https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native/pull/5)
-
 
 ## [1.1.2] - 2021-05-03
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn add -D eslint-config-mig-react-native
 Install the package peer dependencies as development depency (if you don't have them allready).
 
 ```bash
-yarn add -D eslint eslint-config-prettier eslint-plugin-detox eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-react eslint-plugin-react-hooks prettier prettier-eslint-cli @react-native-community/eslint-config typescript @typescript-eslint/parser @typescript-eslint/eslint-plugin
+yarn add -D eslint eslint-config-prettier eslint-plugin-detox eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-react eslint-plugin-react-hooks prettier prettier-eslint-cli @react-native-community/eslint-config typescript @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-simple-import-sort
 ```
 
 ## ESLint configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mig-react-native",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mig-react-native",
-  "version": "1.1.6",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -697,6 +697,12 @@
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
       "dev": true
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "prettier": "^2.2.1"
   },
   "devDependencies": {
@@ -38,6 +39,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "prettier": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native.git"
   },
-  "version": "1.1.6",
+  "version": "1.1.5",
   "description": "eslint config for react native projects developed by the MIG",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/Mobiliteitsfabriek/eslint-config-mig-react-native.git"
   },
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "eslint config for react native projects developed by the MIG",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
![replaced](https://media.giphy.com/media/xUPJPu1t5rak5t7k2Y/giphy.gif)

## Proposal:

Replace the newly introduced import-sort rule with the [simple-import plugin](https://github.com/lydell/eslint-plugin-simple-import-sort).

## Why should we make the proposed changes?

1. Sorry @tritter, we were immediately running into internal linter conflict where the linter was never satisfied with the sort order. Tweaking the default settings helped, but:
2. The sort-import rule only applies `--fix` to the order WITHIN an import (`{ b, a } from 'c'` becomes `{ a, b } from 'c'`). The order of lines would need to be fixed manually for each file, which will be HUGE for existing codebases. The proposed plugin will update all with `--fix`. 

## What will the impact of the changes be?

The sorting will not be as fancily controlled as with the import-sort setting, but a uniform sorting order will still be enforced. Additionally, we will have the ease of use of having autofix work for us.

@tritter you mentioned import-sort had the additional advantage of working well cross-editor. I didn't see a reason why this plugin would not do so, can you check if this proposed change will have a desired effect for your use-case? Thanks! :-)